### PR TITLE
enable ssh_no_exec by default if the "-x" flag is used

### DIFF
--- a/lib/oxidized/script/cli.rb
+++ b/lib/oxidized/script/cli.rb
@@ -25,6 +25,10 @@ module Oxidized
         Config.load(@opts)
         Oxidized.setup_logger
 
+        if @opts[:commands]
+          Oxidized.config.vars.ssh_no_exec = true
+        end
+
         if @cmd_class
           @cmd_class.run :args=>@args, :opts=>@opts, :host=>@host, :cmd=>@cmd
           exit 0


### PR DESCRIPTION
See what you think about this behaviour.  You may have suggestions about a better place to put the check.  Batch configuration now works properly on junos boxes using command files like e.g.

```
configure exclusive
delete protocols bgp
commit and-quit
```
