### PR TITLE
Implementing missing combination of regex with ostype

### DIFF
--- a/lib/oxidized/script/cli.rb
+++ b/lib/oxidized/script/cli.rb
@@ -150,13 +150,24 @@ module Oxidized
       end
 
       def get_hosts
-        if @group and @regex
+        if @ostype and @group and @regex
+          puts "running list for hosts in group: #{@group} and matching ostype: #{@ostype} and matching: #{@regex}" if @verbose
+          nodes_group = run_group @group
+          nodes_ostype = run_ostype @ostype
+          nodes_regex = run_regex @regex
+          return nodes_group & nodes_regex & nodes_ostype
+        elsif @group and @regex
           puts "running list for hosts in group: #{@group} and matching: #{@regex}" if @verbose
           nodes_group = run_group @group
           nodes_regex = run_regex @regex
           return nodes_group & nodes_regex
+        elsif @regex and @ostype
+          puts "running list for hosts matching ostype: #{@ostype} and matching: #{@regex}" if @verbose
+          nodes_regex = run_regex @regex
+          nodes_ostype = run_ostype @ostype
+          return nodes_regex & nodes_ostype
         elsif @group and @ostype
-          puts "running list for hosts in group: #{@group} and matching: #{@ostype}" if @verbose
+          puts "running list for hosts in group: #{@group} and matching ostype: #{@ostype}" if @verbose
           nodes_group = run_group @group
           nodes_ostype = run_ostype @ostype
           return nodes_group & nodes_ostype

--- a/lib/oxidized/script/cli.rb
+++ b/lib/oxidized/script/cli.rb
@@ -151,21 +151,31 @@ module Oxidized
 
       def get_hosts
         puts "running list for hosts" if @verbose
+        if @group
+          puts " - in group: #{@group}" if @verbose
+        end
+        if @ostype
+          puts " - (and) matching ostype: #{@ostype}" if @verbose
+        end
+        if @regex
+          puts " - (and) matching: #{@regex}" if @verbose
+        end
         Oxidized.mgr = Manager.new
         out = []
+        loop_verbose=0   # turn on/off verbose output for the following loop
         Nodes.new.each do |node|
           if @group
-            puts " - in group: #{@group}" if @verbose
+            puts " ... checking if #{node.name} in group: #{@group}, node group is: #{node.group}" if @verbose and loop_verbose>0
             next unless @group == node.group
           end
           if @ostype
-            puts " - (and) matching ostype: #{@ostype}" if @verbose
             @ostype.downcase # need to make sure they are both in lowercase
             nodemodel = node.model.to_s.downcase # need to make sure they are both in lowercase
+            puts " ... checking if #{node.name} matching ostype: #{@ostype}, node ostype is: #{nodemodel}" if @verbose and loop_verbose>0
             next unless nodemodel =~ /#{@ostype}/
           end
           if @regex
-            puts " - (and) matching: #{@regex}" if @verbose
+            puts " ... checking if if #{node.name} matching: #{@regex}" if @verbose and loop_verbose>0
             next unless node.name =~ /#{@regex}/
           end
           out << node.name

--- a/lib/oxidized/script/cli.rb
+++ b/lib/oxidized/script/cli.rb
@@ -150,66 +150,24 @@ module Oxidized
       end
 
       def get_hosts
-        if @ostype and @group and @regex
-          puts "running list for hosts in group: #{@group} and matching ostype: #{@ostype} and matching: #{@regex}" if @verbose
-          nodes_group = run_group @group
-          nodes_ostype = run_ostype @ostype
-          nodes_regex = run_regex @regex
-          return nodes_group & nodes_regex & nodes_ostype
-        elsif @group and @regex
-          puts "running list for hosts in group: #{@group} and matching: #{@regex}" if @verbose
-          nodes_group = run_group @group
-          nodes_regex = run_regex @regex
-          return nodes_group & nodes_regex
-        elsif @regex and @ostype
-          puts "running list for hosts matching ostype: #{@ostype} and matching: #{@regex}" if @verbose
-          nodes_regex = run_regex @regex
-          nodes_ostype = run_ostype @ostype
-          return nodes_regex & nodes_ostype
-        elsif @group and @ostype
-          puts "running list for hosts in group: #{@group} and matching ostype: #{@ostype}" if @verbose
-          nodes_group = run_group @group
-          nodes_ostype = run_ostype @ostype
-          return nodes_group & nodes_ostype
-        elsif @regex
-          puts 'running list for hosts matching: ' + @regex if @verbose
-          return run_regex @regex
-        elsif @ostype
-          puts 'running list for hosts matching ostype: ' + @ostype if @verbose
-          return run_ostype @ostype
-        else
-          puts 'running list for hosts in group: ' + @group if @verbose
-          return run_group @group
-        end
-      end
-
-      def run_group group
+        puts "running list for hosts" if @verbose
         Oxidized.mgr = Manager.new
         out = []
         Nodes.new.each do |node|
-          next unless group == node.group
-          out << node.name
-        end
-        out
-      end
-
-      def run_ostype ostype
-        Oxidized.mgr = Manager.new
-        out = []
-        Nodes.new.each do |node|
-          ostype.downcase # need to make sure they are both in lowercase
-          nodemodel = node.model.to_s.downcase # need to make sure they are both in lowercase
-          next unless nodemodel =~ /#{ostype}/ 
-          out << node.name
-        end
-        out
-      end
-
-      def run_regex regex
-        Oxidized.mgr = Manager.new
-        out = []
-        Nodes.new.each do |node|
-          next unless node.name =~ /#{regex}/
+          if @group
+            puts " - in group: #{@group}" if @verbose
+            next unless @group == node.group
+          end
+          if @ostype
+            puts " - (and) matching ostype: #{@ostype}" if @verbose
+            @ostype.downcase # need to make sure they are both in lowercase
+            nodemodel = node.model.to_s.downcase # need to make sure they are both in lowercase
+            next unless nodemodel =~ /#{@ostype}/
+          end
+          if @regex
+            puts " - (and) matching: #{@regex}" if @verbose
+            next unless node.name =~ /#{@regex}/
+          end
           out << node.name
         end
         out


### PR DESCRIPTION
Hello,

I implemented the other combinations of group, ostype und regex. This might look like a feature, but missing this it feels like a bug. Especially since it is not clearly documented. The documentation reads to me like they may be (all) combined. But only some of them were combineable, the changes from this pull request are fixing this.

I first seached why the ostype filter was ignored, and oxidized was trying to apply the configuration changes, on other ostypes where they can't work. 

We are using the groups for the big topological distinctions within our network. Naming conventions for hierarchical distinctions. And within the same device role there are sometimes two different vendors in use. So I needed this for configuration rollout.

I also made clearer (in line 159/170) which match is ostype and which is regex. You already started to do this, and in my new lines this was IMHO strictly necessary, to make clear what is meant within the debug output. ;-)

Kind regards,
     Lars