### PR TITLE
Oxidized.setup_logger retired

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 - fixed --list-models (@nickhilliard)
 - return exception if host specification line returns no hosts (@nickhilliard)
+- Remove Oxidized.setup_logger from CLI initialization (@nickhilliard)
 
 ## [0.7.0 - 2025-01-21]
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,6 @@ Usage: oxs [options] hostname [command]
 require 'oxidized/script'
 
 Oxidized::Config.load
-Oxidized.setup_logger
 
 Oxidized::Script.new(:host=>'62.236.123.199') do |oxs|
   puts oxs.cmd 'show mac address-table dynamic vlan 101'

--- a/lib/oxidized/script/cli.rb
+++ b/lib/oxidized/script/cli.rb
@@ -49,7 +49,6 @@ module Oxidized
         @args, @opts = opts_parse load_dynamic
 
         Config.load(@opts)
-        Oxidized.setup_logger
 
         if @opts[:commands]
           Oxidized.config.vars.ssh_no_exec = true


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->
Closes issue #73
<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed an obsolete logger initialization from the startup flow to prevent redundant logging behavior.
* **Documentation**
  * Updated usage examples and README to remove the now-removed logger setup call so examples reflect current startup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->